### PR TITLE
Corregido el crash bonus

### DIFF
--- a/new_main_jetpac.cc
+++ b/new_main_jetpac.cc
@@ -174,7 +174,7 @@ void DrawingSprites(){
 }  //VAMOH A DIBUJAR
 
 void Collisions () {
-  if(str_bonus.coll_bonus == false) { BonusCollision(); }
+  if(str_bonus.coll_bonus == false && str_bonus.is_alive == true) { BonusCollision(); }
 }
 
 


### PR DESCRIPTION
Añadido un && is alive a la condición de colisión del bonus para que no crashee.